### PR TITLE
Add new view appointments command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,6 +141,12 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the address book.
 * `find Monica` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
+### Viewing all appointments : `appointments`
+
+Displays all current appointments across all users from the address book.
+
+Format: `appointments`
+
 ### Clearing all entries : `clear`
 
 Clears all entries from the address book.

--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Shows all appointments in the filtered address book.
+ */
+public class ViewAppointmentsCommand extends Command {
+
+    public static final String COMMAND_WORD = "appointments";
+
+    public static final String MESSAGE_SUCCESS = "Listed all appointments";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all appointments with everyone in the address book.\n"
+            + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        // Get all appointments from the last shown list of persons
+        List<String> appointments = lastShownList.stream()
+                .flatMap(person -> person.getAppointments().stream())
+                .map(Object::toString)
+                .collect(Collectors.toList());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Appointments:\n");
+        for (String appointment : appointments) {
+            sb.append(appointment).append("\n");
+        }
+
+        return new CommandResult(sb.toString().trim());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewAppointmentsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewAppointmentsCommand.COMMAND_WORD:
+            return new ViewAppointmentsCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -81,7 +81,7 @@ public class AddressBookParser {
 
         case ViewAppointmentsCommand.COMMAND_WORD:
             return new ViewAppointmentsCommand();
-            
+
         case NoteCommand.COMMAND_WORD:
             return new NoteCommandParser().parse(arguments);
 

--- a/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ViewAppointmentsCommand.
+ */
+public class ViewAppointmentsCommandTest {
+
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    // Basic test for now, will include more as we develop.
+    @Test
+    public void execute_viewAppointments_success() {
+        String expectedMessage = "Appointments:\n"
+                + "23:59 SUN";
+        assertCommandSuccess(new ViewAppointmentsCommand(), model, expectedMessage, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
@@ -29,7 +29,7 @@ public class ViewAppointmentsCommandTest {
     @Test
     public void execute_viewAppointments_success() {
         String expectedMessage = "Appointments:\n"
-                + "23:59 SUN";
+                + "12:00-13:00 SUN";
         assertCommandSuccess(new ViewAppointmentsCommand(), model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewAppointmentsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +87,11 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_viewAppointments() throws Exception {
+        assertTrue(parser.parseCommand(ViewAppointmentsCommand.COMMAND_WORD) instanceof ViewAppointmentsCommand);
     }
 
     @Test


### PR DESCRIPTION
TutorRec now supports appointments.

But there is no way to view all appointments as of yet.

Let's:
* Add a new command to view all current appointments.
* Update AddressBookParser to recognise the new command.
* Add in the relevant tests.

The basic command will output all current appointments in the addressbook in the Result display stackpane below the Command box. 