### PR TITLE
Update appointments command to show contact names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -28,7 +29,9 @@ public class ViewAppointmentsCommand extends Command {
 
         // Get all appointments from the last shown list of persons
         List<String> appointments = lastShownList.stream()
-                .flatMap(person -> person.getAppointments().stream())
+                .flatMap(person -> person.hasAppointments()
+                        ? Stream.concat(Stream.of("\n" + person.getName()), person.getAppointments().stream())
+                        : Stream.empty())
                 .map(Object::toString)
                 .collect(Collectors.toList());
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -79,6 +79,13 @@ public class Person {
     }
 
     /**
+     * Returns a boolean value which indicates whether the person has any appointments.
+     */
+    public boolean hasAppointments() {
+        return !appointments.isEmpty();
+    }
+
+    /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */

--- a/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
@@ -25,10 +25,11 @@ public class ViewAppointmentsCommandTest {
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
     }
 
-    // Basic test for now, will include more as we develop.
+    // Test modified to account for revised Appointment command where contact name is shown
     @Test
     public void execute_viewAppointments_success() {
         String expectedMessage = "Appointments:\n"
+                + "\nBenson Meier\n"
                 + "12:00-13:00 SUN";
         assertCommandSuccess(new ViewAppointmentsCommand(), model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -93,6 +93,13 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // no appointments -> returns false
+        assertFalse(ALICE.hasAppointments());
+
+        // has appointments -> returns true;
+        editedAlice = new PersonBuilder(ALICE).withAppointments("08:00-09:00 SUN").build();
+        assertTrue(editedAlice.hasAppointments());
     }
 
     @Test


### PR DESCRIPTION
Updated the appointments command to show the name of the contact associated with the relevant appointments. Also added in code to test the new hasAppointments() in Person that is used for this change.

Fixes #87.