### PR TITLE
Updates the prefixes detection 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.INCORRECT_PREFIX_MAP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -39,8 +40,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_NOTE, PREFIX_TAG, PREFIX_APPOINTMENT, PREFIX_SUBJECT, PREFIX_LEVEL);
+                ArgumentTokenizer.tokenize(args, INCORRECT_PREFIX_MAP, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_TAG, PREFIX_APPOINTMENT, PREFIX_SUBJECT, PREFIX_LEVEL);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -19,13 +21,37 @@ public class ArgumentTokenizer {
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps prefixes to their
      * respective argument values. Only the given prefixes will be recognized in the arguments string.
      *
-     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
-     * @param prefixes   Prefixes to tokenize the arguments string with
-     * @return           ArgumentMultimap object that maps prefixes to their arguments
+     * @param argsString            Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param incorrectPrefixes     A list of incorrect prefixes to check against.
+     * @param prefixes              Prefixes to tokenize the arguments string with
+     * @return                      ArgumentMultimap object that maps prefixes to their arguments
      */
-    public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
-        List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
-        return extractArguments(argsString, positions);
+    public static ArgumentMultimap tokenize(String argsString, HashMap<Prefix,
+            List<String>> incorrectPrefixes, Prefix... prefixes) {
+        String correctedArgsString = fixIncorrectPrefixes(argsString, incorrectPrefixes);
+        List<PrefixPosition> positions = findAllPrefixPositions(correctedArgsString, prefixes);
+        return extractArguments(correctedArgsString, positions);
+    }
+
+    /**
+     * Corrects incorrect prefixes in an arguments string using a provided mapping.
+     *
+     * @param argsString The string containing potentially incorrect prefixes.
+     * @param incorrectPrefixes A map of correct prefixes to their respective list of common incorrect variations.
+     * @return The corrected arguments string with all known incorrect prefixes replaced by their correct versions.
+     */
+    public static String fixIncorrectPrefixes(String argsString, HashMap<Prefix, List<String>> incorrectPrefixes) {
+        // Iterate over each entry in the incorrectPrefixes map
+        for (Map.Entry<Prefix, List<String>> entry : incorrectPrefixes.entrySet()) {
+            Prefix correctPrefix = entry.getKey();
+            List<String> incorrectPrefixList = entry.getValue();
+
+            // Replace each incorrect prefix with the correct one
+            for (String incorrectPrefix : incorrectPrefixList) {
+                argsString = argsString.replace(incorrectPrefix, correctPrefix.getPrefix());
+            }
+        }
+        return argsString;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.parser;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
@@ -15,5 +20,28 @@ public class CliSyntax {
     public static final Prefix PREFIX_APPOINTMENT = new Prefix("ap/");
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_LEVEL = new Prefix("l/");
+
+    /*
+   Incorrect but acceptable prefixes. We may add more as required.
+ */
+    public static final HashMap<Prefix, List<String>> INCORRECT_PREFIX_MAP = new HashMap<>();
+
+    static {
+        // Populate the map with common incorrect prefixes
+        INCORRECT_PREFIX_MAP.put(PREFIX_NAME, Arrays.asList("name/", "nae/", "nam/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_PHONE, Arrays.asList("phone/", "phon/", "pho/", "ph/", "hp/", "/handphone"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_EMAIL, Arrays.asList("email/", "emai/", "eml/", "em/", "ema/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_ADDRESS, Arrays.asList("address/", "addr/", "add/",
+                "ad/", "addres/", "adress/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_NOTE, Arrays.asList("note/", "not/", "nt/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_TAG, Arrays.asList("tag/", "ta/", "tg/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_APPOINTMENT, Arrays.asList("appointment/", "appt/", "apt/",
+                "appoint/", "app/", "appointmen/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_SUBJECT, Arrays.asList("subject/", "subj/", "sub/",
+                "subjec/", "subjet/", "subje/", "su/", "ubject/"));
+        INCORRECT_PREFIX_MAP.put(PREFIX_LEVEL, Arrays.asList("level/", "lvl/", "leve/",
+                "lv/", "le/", "lev/", "lvel/", "evel/"));
+    }
+
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.INCORRECT_PREFIX_MAP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -37,8 +38,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NOTE,
-                        PREFIX_TAG, PREFIX_APPOINTMENT, PREFIX_SUBJECT, PREFIX_LEVEL);
+                ArgumentTokenizer.tokenize(args, INCORRECT_PREFIX_MAP, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_TAG, PREFIX_APPOINTMENT, PREFIX_SUBJECT, PREFIX_LEVEL);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.INCORRECT_PREFIX_MAP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import seedu.address.commons.core.index.Index;
@@ -23,7 +24,7 @@ public class NoteCommandParser implements Parser<NoteCommand> {
     public NoteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-            PREFIX_NOTE);
+            INCORRECT_PREFIX_MAP, PREFIX_NOTE);
 
         Index index;
         try {

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.INCORRECT_PREFIX_MAP;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_emptyArgsString_noValues() {
         String argsString = "  ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash);
 
         assertPreambleEmpty(argMultimap);
         assertArgumentAbsent(argMultimap, pSlash);
@@ -56,7 +57,7 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_noPrefixes_allTakenAsPreamble() {
         String argsString = "  some random string /t tag with leading and trailing spaces ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed
         assertPreamblePresent(argMultimap, argsString.trim());
@@ -67,13 +68,13 @@ public class ArgumentTokenizerTest {
     public void tokenize_oneArgument() {
         // Preamble present
         String argsString = "  Some preamble string p/ Argument value ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash);
         assertPreamblePresent(argMultimap, "Some preamble string");
         assertArgumentPresent(argMultimap, pSlash, "Argument value");
 
         // No preamble
         argsString = " p/   Argument value ";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash);
         assertPreambleEmpty(argMultimap);
         assertArgumentPresent(argMultimap, pSlash, "Argument value");
 
@@ -83,7 +84,8 @@ public class ArgumentTokenizerTest {
     public void tokenize_multipleArguments() {
         // Only two arguments are present
         String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP,
+                pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value");
@@ -91,7 +93,7 @@ public class ArgumentTokenizerTest {
 
         // All three arguments are present
         argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "Different Preamble String");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value");
@@ -102,7 +104,7 @@ public class ArgumentTokenizerTest {
         // Reuse tokenizer on an empty string to ensure ArgumentMultimap is correctly reset
         // (i.e. no stale values from the previous tokenizing remain)
         argsString = "";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash, dashT, hatQ);
         assertPreambleEmpty(argMultimap);
         assertArgumentAbsent(argMultimap, pSlash);
 
@@ -110,7 +112,7 @@ public class ArgumentTokenizerTest {
 
         // Prefixes not previously given to the tokenizer should not return any values
         argsString = unknownPrefix + "some value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP, pSlash, dashT, hatQ);
         assertArgumentAbsent(argMultimap, unknownPrefix);
         assertPreamblePresent(argMultimap, argsString); // Unknown prefix is taken as part of preamble
     }
@@ -119,7 +121,8 @@ public class ArgumentTokenizerTest {
     public void tokenize_multipleArgumentsWithRepeats() {
         // Two arguments repeated, some have empty values
         String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP,
+                pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
@@ -129,7 +132,8 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArgumentsJoined() {
         String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, INCORRECT_PREFIX_MAP,
+                pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
         assertArgumentAbsent(argMultimap, pSlash);
         assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");


### PR DESCRIPTION
Updates the prefixes and argument tokenizer to accept slightly incorrect variations or long form variations of prefixes.

The current implementation opts for manual detection rather than a more complex algorithmic detection.

The current implementation does not warn users,
but detects the typo and accepts the command.