### PR TITLE
Fix display bug

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -58,7 +58,7 @@ public class Messages {
         builder.append("; Subjects: ");
         person.getSubjects().forEach(builder::append);
 
-        if (!person.getNote().isEmpty()) {
+        if (!person.getLevel().isEmpty()) {
             builder.append("; Level: ").append(person.getLevel());
         }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -51,8 +51,17 @@ public class Messages {
         }
         builder.append("; Tags: ");
         person.getTags().forEach(builder::append);
+
         builder.append("; Appointments: ");
         person.getAppointments().forEach(builder::append);
+
+        builder.append("; Subjects: ");
+        person.getSubjects().forEach(builder::append);
+
+        if (!person.getNote().isEmpty()) {
+            builder.append("; Level: ").append(person.getLevel());
+        }
+
         return builder.toString();
     }
 


### PR DESCRIPTION
Fixed bug that does not display subject and level in output.

Now when

`return new CommandResult(
                   String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));`

is called, Messages.format(Person) will include subject and levels.

And the output for add and edit will include both fields.