### PR TITLE
Sort/filter functionality for view appointment

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -224,9 +224,18 @@ Examples:
 
 ### Viewing all appointments : `appointments`
 
-Displays all appointments of persons currently displayed in the list, along with the persons involved.
+Displays all appointments of persons currently displayed in the list, sorted, along with the persons involved. 
+Optionally, you may specify a `DAY` or multiple `DAY`s to further restrict the appointments displayed.
 
-Format: `appointments`
+Format: `appointments [DAY]`
+
+* `DAY` must be one of `MON`, `TUE`, ..., `SUN`.
+* `[DAY]` may be empty.
+
+Examples:
+* `appointments` returns all appointments among the displayed persons.
+* `appointments MON` returns all appointments among the displayed persons on Monday.
+* `appointments MON TUE` returns all appointments among the displayed persons on Monday and Tuesday.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
@@ -22,7 +22,10 @@ public class ViewAppointmentsCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists all appointments of persons displayed.\n"
-            + "Example: " + COMMAND_WORD;
+            + "Example: " + COMMAND_WORD + "\n"
+            + "or\n"
+            + COMMAND_WORD + " [DAY_OF_WEEK]: Lists all appointments on the days of the week specified.\n"
+            + "Example: " + COMMAND_WORD + " MON\n, " + COMMAND_WORD + " MON TUE\n";
 
     private final AppointmentIsDayOfWeekPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
 import seedu.address.model.Model;
+import seedu.address.model.appointment.AppointmentIsDayOfWeekPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -19,8 +21,14 @@ public class ViewAppointmentsCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all appointments";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists all appointments with everyone in the address book.\n"
+            + ": Lists all appointments of persons displayed.\n"
             + "Example: " + COMMAND_WORD;
+
+    private final AppointmentIsDayOfWeekPredicate predicate;
+
+    public ViewAppointmentsCommand(AppointmentIsDayOfWeekPredicate predicate) {
+        this.predicate = predicate;
+    }
 
     @Override
     public CommandResult execute(Model model) {
@@ -30,17 +38,23 @@ public class ViewAppointmentsCommand extends Command {
         // Get all appointments from the last shown list of persons
         List<String> appointments = lastShownList.stream()
                 .flatMap(person -> person.hasAppointments()
-                        ? Stream.concat(
-                                Stream.of("\n" + person.getName()), person.getAppointments()
-                                .asUnmodifiableObservableList().stream())
+                        ? person.getAppointments()
+                        .asUnmodifiableObservableList().stream()
+                        .filter(predicate)
+                        .map(appointment -> new Pair<>(appointment, person.getName().toString()))
                         : Stream.empty())
-                .map(Object::toString)
+                .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey())) // comparing by appointment only
+                .map(pair -> pair.getValue() + ": " + pair.getKey().toString())
                 .collect(Collectors.toList());
 
         StringBuilder sb = new StringBuilder();
         sb.append("Appointments:\n");
         for (String appointment : appointments) {
             sb.append(appointment).append("\n");
+        }
+
+        if (appointments.isEmpty()) {
+            sb.append("There are no appointments to show!");
         }
 
         return new CommandResult(sb.toString().trim());

--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentsCommand.java
@@ -62,4 +62,19 @@ public class ViewAppointmentsCommand extends Command {
 
         return new CommandResult(sb.toString().trim());
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ViewAppointmentsCommand)) {
+            return false;
+        }
+
+        ViewAppointmentsCommand otherCommand = (ViewAppointmentsCommand) other;
+        return predicate.equals(otherCommand.predicate);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -81,7 +81,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case ViewAppointmentsCommand.COMMAND_WORD:
-            return new ViewAppointmentsCommand();
+            return new ViewAppointmentsCommandParser().parse(arguments);
 
         case NoteCommand.COMMAND_WORD:
             return new NoteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ViewAppointmentsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewAppointmentsCommandParser.java
@@ -32,15 +32,22 @@ public class ViewAppointmentsCommandParser implements Parser<ViewAppointmentsCom
             return new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(defaultDayOfWeeks));
         }
 
-        try {
-            String[] days = trimmedArgs.split("\\s+");
-            List<DayOfWeek> dayOfWeeks = Stream.of(days).map(String::toUpperCase)
-                    .map(Appointment.DAY_TO_DAY_OF_WEEK::get)
-                    .collect(Collectors.toList());
-            return new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(dayOfWeeks));
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewAppointmentsCommand.MESSAGE_USAGE));
+        String[] days = trimmedArgs.split("\\s+");
+        List<String> dayList = Stream.of(days).map(String::toUpperCase).collect(Collectors.toList());
+
+        // check that all day in dayList are valid day of the week
+        for (String day : dayList) {
+            if (!Appointment.DAY_TO_DAY_OF_WEEK.containsKey(day)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewAppointmentsCommand.MESSAGE_USAGE));
+            }
         }
+
+        List<DayOfWeek> dayOfWeekList = dayList.stream()
+                .map(Appointment.DAY_TO_DAY_OF_WEEK::get)
+                .distinct()
+                .collect(Collectors.toList());
+
+        return new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(dayOfWeekList));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewAppointmentsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewAppointmentsCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ViewAppointmentsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentIsDayOfWeekPredicate;
+
+/**
+ * Parses input arguments and creates a new ViewAppointmentsCommand object.
+ * Code is borrowed from existing ViewCommandParser.java due to similarities in desired implementation.
+ */
+public class ViewAppointmentsCommandParser implements Parser<ViewAppointmentsCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of ViewAppointmentsCommand and returns
+     * a ViewAppointmentsCommand object for execution.
+     * @throws ParseException if the user input does not conform to expected format.
+     */
+    public ViewAppointmentsCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim().toUpperCase();
+        if (trimmedArgs.isEmpty()) {
+
+            // add all days of the week to the list
+            List<DayOfWeek> defaultDayOfWeeks = new ArrayList<>(Appointment.DAY_OF_WEEK_TO_NUM.keySet());
+            return new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(defaultDayOfWeeks));
+        }
+
+        try {
+            String[] days = trimmedArgs.split("\\s+");
+            List<DayOfWeek> dayOfWeeks = Stream.of(days).map(String::toUpperCase)
+                    .map(Appointment.DAY_TO_DAY_OF_WEEK::get)
+                    .collect(Collectors.toList());
+            return new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(dayOfWeeks));
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewAppointmentsCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -22,6 +22,8 @@ public class Appointment implements Comparable<Appointment> {
             + "MM is from 00 to 59.\n"
             + "2. This is followed by a DAY. "
             + "DAY must be one of: 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT','SUN'\n";
+    public static final HashMap<String, DayOfWeek> DAY_TO_DAY_OF_WEEK;
+    public static final HashMap<DayOfWeek, Integer> DAY_OF_WEEK_TO_NUM;
     // alphanumeric and special characters
     private static final String HOUR = "[\\d]{2}";
     private static final String MINUTE = "[\\d]{2}";
@@ -30,28 +32,25 @@ public class Appointment implements Comparable<Appointment> {
     private static final String DAY = "[A-z]{3}";
     public static final String VALIDATION_REGEX = START_TIME + "-" + END_TIME + "[\\s]+" + DAY;
 
-    private static final HashMap<String, DayOfWeek> dayToDayOfWeek;
-    private static final HashMap<DayOfWeek, Integer> dayOfWeekToNum;
-
     // initialize map from String to DayOfWeek
     static {
-        dayToDayOfWeek = new HashMap<>();
-        dayToDayOfWeek.put("MON", DayOfWeek.MONDAY);
-        dayToDayOfWeek.put("TUE", DayOfWeek.TUESDAY);
-        dayToDayOfWeek.put("WED", DayOfWeek.WEDNESDAY);
-        dayToDayOfWeek.put("THU", DayOfWeek.THURSDAY);
-        dayToDayOfWeek.put("FRI", DayOfWeek.FRIDAY);
-        dayToDayOfWeek.put("SAT", DayOfWeek.SATURDAY);
-        dayToDayOfWeek.put("SUN", DayOfWeek.SUNDAY);
+        DAY_TO_DAY_OF_WEEK = new HashMap<>();
+        DAY_TO_DAY_OF_WEEK.put("MON", DayOfWeek.MONDAY);
+        DAY_TO_DAY_OF_WEEK.put("TUE", DayOfWeek.TUESDAY);
+        DAY_TO_DAY_OF_WEEK.put("WED", DayOfWeek.WEDNESDAY);
+        DAY_TO_DAY_OF_WEEK.put("THU", DayOfWeek.THURSDAY);
+        DAY_TO_DAY_OF_WEEK.put("FRI", DayOfWeek.FRIDAY);
+        DAY_TO_DAY_OF_WEEK.put("SAT", DayOfWeek.SATURDAY);
+        DAY_TO_DAY_OF_WEEK.put("SUN", DayOfWeek.SUNDAY);
 
-        dayOfWeekToNum = new HashMap<>();
-        dayOfWeekToNum.put(DayOfWeek.MONDAY, 1);
-        dayOfWeekToNum.put(DayOfWeek.TUESDAY, 2);
-        dayOfWeekToNum.put(DayOfWeek.WEDNESDAY, 3);
-        dayOfWeekToNum.put(DayOfWeek.THURSDAY, 4);
-        dayOfWeekToNum.put(DayOfWeek.FRIDAY, 5);
-        dayOfWeekToNum.put(DayOfWeek.SATURDAY, 6);
-        dayOfWeekToNum.put(DayOfWeek.SUNDAY, 7);
+        DAY_OF_WEEK_TO_NUM = new HashMap<>();
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.MONDAY, 1);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.TUESDAY, 2);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.WEDNESDAY, 3);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.THURSDAY, 4);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.FRIDAY, 5);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.SATURDAY, 6);
+        DAY_OF_WEEK_TO_NUM.put(DayOfWeek.SUNDAY, 7);
     }
 
     public final String value;
@@ -71,7 +70,7 @@ public class Appointment implements Comparable<Appointment> {
         value = appointment.toUpperCase();
         startTime = LocalTime.parse(extractStartTime(appointment));
         endTime = LocalTime.parse(extractEndTime(appointment));
-        day = dayToDayOfWeek.get(extractDay(appointment));
+        day = DAY_TO_DAY_OF_WEEK.get(extractDay(appointment));
     }
 
     /**
@@ -112,7 +111,7 @@ public class Appointment implements Comparable<Appointment> {
         boolean isStartTimeBeforeEndTime = startTime.isBefore(endTime);
 
         String day = extractDay(test);
-        boolean isDayValid = dayToDayOfWeek.containsKey(day);
+        boolean isDayValid = DAY_TO_DAY_OF_WEEK.containsKey(day);
 
         return isStartTimeBeforeEndTime && isDayValid;
     }
@@ -139,6 +138,18 @@ public class Appointment implements Comparable<Appointment> {
 
     private static String extractDay(String appointment) {
         return appointment.substring(12).trim().toUpperCase();
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public DayOfWeek getDay() {
+        return day;
     }
 
     @Override
@@ -187,9 +198,9 @@ public class Appointment implements Comparable<Appointment> {
 
     @Override
     public int compareTo(Appointment o) {
-        if (dayOfWeekToNum.get(this.day) < dayOfWeekToNum.get(o.day)) {
+        if (DAY_OF_WEEK_TO_NUM.get(this.day) < DAY_OF_WEEK_TO_NUM.get(o.day)) {
             return -1;
-        } else if (dayOfWeekToNum.get(this.day) > dayOfWeekToNum.get(o.day)) {
+        } else if (DAY_OF_WEEK_TO_NUM.get(this.day) > DAY_OF_WEEK_TO_NUM.get(o.day)) {
             return 1;
         } else {
             return this.startTime.compareTo(o.startTime);

--- a/src/main/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.appointment;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
+public class AppointmentIsDayOfWeekPredicate implements Predicate<Appointment> {
+    private final List<DayOfWeek> days;
+
+    public AppointmentIsDayOfWeekPredicate(List<DayOfWeek> dayOfWeeks) {
+        this.days = dayOfWeeks;
+    }
+
+    @Override
+    public boolean test(Appointment appointment) {
+        return days.stream().anyMatch(day -> day.equals(appointment.getDay()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof seedu.address.model.appointment.AppointmentIsDayOfWeekPredicate)) {
+            return false;
+        }
+
+        AppointmentIsDayOfWeekPredicate otherPredicate = (AppointmentIsDayOfWeekPredicate) other;
+        return this.days.equals(otherPredicate.days);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("days", days).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewAppointmentsCommandTest.java
@@ -3,12 +3,17 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.time.DayOfWeek;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.appointment.AppointmentIsDayOfWeekPredicate;
+
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ViewAppointmentsCommand.
@@ -29,9 +34,17 @@ public class ViewAppointmentsCommandTest {
     @Test
     public void execute_viewAppointments_success() {
         String expectedMessage = "Appointments:\n"
-                + "\nBenson Meier\n"
-                + "12:00-13:00 SUN";
-        assertCommandSuccess(new ViewAppointmentsCommand(), model, expectedMessage, expectedModel);
+                + "Benson Meier: 12:00-13:00 SUN";
+        assertCommandSuccess(new ViewAppointmentsCommand(
+                new AppointmentIsDayOfWeekPredicate(List.of(DayOfWeek.SUNDAY))), model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_viewAppointmentsWithPredicate_success() {
+        String expectedMessage = "Appointments:\n"
+                + "There are no appointments to show!";
+        assertCommandSuccess(new ViewAppointmentsCommand(
+                new AppointmentIsDayOfWeekPredicate(List.of(DayOfWeek.MONDAY))), model, expectedMessage, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ViewAppointmentsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewAppointmentsCommandParserTest.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ViewAppointmentsCommand;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentIsDayOfWeekPredicate;
+
+public class ViewAppointmentsCommandParserTest {
+
+    private ViewAppointmentsCommandParser parser = new ViewAppointmentsCommandParser();
+
+    @Test
+    public void parse_emptyArg_returnsViewAppointmentsCommand() {
+        ViewAppointmentsCommand expectedViewAppointmentsCommand =
+                new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(
+                        new ArrayList<>(Appointment.DAY_OF_WEEK_TO_NUM.keySet())));
+        // whitespace
+        assertParseSuccess(parser, "       ", expectedViewAppointmentsCommand);
+
+        // weird whitespace
+        assertParseSuccess(parser, " \n   \t", expectedViewAppointmentsCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsViewAppointmentsCommand() {
+        // no leading and trailing whitespaces
+        ViewAppointmentsCommand expectedViewAppointmentsCommand =
+                new ViewAppointmentsCommand(new AppointmentIsDayOfWeekPredicate(
+                        Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)));
+        assertParseSuccess(parser, "mon Tue", expectedViewAppointmentsCommand);
+
+        // multiple whitespaces between days
+        assertParseSuccess(parser, " \n mon \n \t Tue  \t", expectedViewAppointmentsCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // not days
+        assertParseFailure(parser, "mon Tues",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewAppointmentsCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
@@ -1,5 +1,5 @@
 package seedu.address.model.appointment;
 
 public class AppointmentIsDayOfWeekPredicate {
-    
+
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
@@ -1,0 +1,5 @@
+package seedu.address.model.appointment;
+
+public class AppointmentIsDayOfWeekPredicate {
+    
+}

--- a/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicate.java
@@ -1,5 +1,0 @@
-package seedu.address.model.appointment;
-
-public class AppointmentIsDayOfWeekPredicate {
-
-}

--- a/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicateTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicateTest.java
@@ -1,0 +1,75 @@
+package seedu.address.model.appointment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class AppointmentIsDayOfWeekPredicateTest {
+
+    @Test
+    public void equals() {
+        List<DayOfWeek> firstPredicateDayOfWeekList = Collections.singletonList(DayOfWeek.MONDAY);
+        List<DayOfWeek> secondPredicateDayOfWeekList = Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY);
+
+        AppointmentIsDayOfWeekPredicate firstPredicate = new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
+        AppointmentIsDayOfWeekPredicate secondPredicate = new AppointmentIsDayOfWeekPredicate(secondPredicateDayOfWeekList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AppointmentIsDayOfWeekPredicate firstPredicateCopy = new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different appointment -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_dayOfWeekMatches_returnsTrue() {
+        // Single day match
+        AppointmentIsDayOfWeekPredicate predicate = new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
+        assertTrue(predicate.test(new Appointment("09:00-10:00 MON")));
+
+        // Multiple days match
+        predicate = new AppointmentIsDayOfWeekPredicate(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY));
+        assertTrue(predicate.test(new Appointment("09:00-10:00 TUE")));
+
+        // Mixed-case keywords
+        predicate = new AppointmentIsDayOfWeekPredicate(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY));
+        assertTrue(predicate.test(new Appointment("09:00-10:00 mon")));
+    }
+
+    @Test
+    public void test_dayOfWeekDoesNotMatch_returnsFalse() {
+        // No day match
+        AppointmentIsDayOfWeekPredicate predicate = new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
+        assertFalse(predicate.test(new Appointment("09:00-10:00 TUE")));
+
+        // Different day match
+        predicate = new AppointmentIsDayOfWeekPredicate(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY));
+        assertFalse(predicate.test(new Appointment("09:00-10:00 TUE")));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<DayOfWeek> daysOfWeek = List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY);
+        AppointmentIsDayOfWeekPredicate predicate = new AppointmentIsDayOfWeekPredicate(daysOfWeek);
+
+        String expected = AppointmentIsDayOfWeekPredicate.class.getCanonicalName() + "{days=" + daysOfWeek + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicateTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentIsDayOfWeekPredicateTest.java
@@ -18,14 +18,17 @@ public class AppointmentIsDayOfWeekPredicateTest {
         List<DayOfWeek> firstPredicateDayOfWeekList = Collections.singletonList(DayOfWeek.MONDAY);
         List<DayOfWeek> secondPredicateDayOfWeekList = Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY);
 
-        AppointmentIsDayOfWeekPredicate firstPredicate = new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
-        AppointmentIsDayOfWeekPredicate secondPredicate = new AppointmentIsDayOfWeekPredicate(secondPredicateDayOfWeekList);
+        AppointmentIsDayOfWeekPredicate firstPredicate =
+                new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
+        AppointmentIsDayOfWeekPredicate secondPredicate =
+                new AppointmentIsDayOfWeekPredicate(secondPredicateDayOfWeekList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        AppointmentIsDayOfWeekPredicate firstPredicateCopy = new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
+        AppointmentIsDayOfWeekPredicate firstPredicateCopy =
+                new AppointmentIsDayOfWeekPredicate(firstPredicateDayOfWeekList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,7 +44,8 @@ public class AppointmentIsDayOfWeekPredicateTest {
     @Test
     public void test_dayOfWeekMatches_returnsTrue() {
         // Single day match
-        AppointmentIsDayOfWeekPredicate predicate = new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
+        AppointmentIsDayOfWeekPredicate predicate =
+                new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
         assertTrue(predicate.test(new Appointment("09:00-10:00 MON")));
 
         // Multiple days match
@@ -56,7 +60,8 @@ public class AppointmentIsDayOfWeekPredicateTest {
     @Test
     public void test_dayOfWeekDoesNotMatch_returnsFalse() {
         // No day match
-        AppointmentIsDayOfWeekPredicate predicate = new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
+        AppointmentIsDayOfWeekPredicate predicate =
+                new AppointmentIsDayOfWeekPredicate(Collections.singletonList(DayOfWeek.MONDAY));
         assertFalse(predicate.test(new Appointment("09:00-10:00 TUE")));
 
         // Different day match


### PR DESCRIPTION
Closes #86
This pull request introduces sort and filter functionality for viewing appointments, enhancing the usability of the application. The implementation includes the following key components:

1. **AppointmentIsDayOfWeekPredicate:** This class allows filtering appointments based on specified days of the week.
a. Does not validate for unique days, i.e. the command `appointments mon mon` would be allowed and mean the same thing as `appointments mon`.
b. Allows multiple days to be specified, i.e. the command `appointments mon tue` is permissible.
2. **AppointmentIsDayOfWeekPredicateTest:** A comprehensive test suite validating the functionality of the AppointmentIsDayOfWeekPredicate class. It ensures that appointments are correctly filtered based on the specified days of the week.
3.  **ViewAppointmentsCommand** updated to support filter. The default behaviour is to list all appointments belonging to the displayed persons, sorted chronologically.
4. **Updates to the user guide**.