### PR TITLE
Allow removing level and subject fields

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -200,8 +200,13 @@ public class ParserUtil {
      * @throws ParseException if the given {@code subject} is invalid.
      */
     private static Subject parseSubject(String subject) throws ParseException {
-        requireNonNull(subject);
+        if (subject == null) {
+            return null;
+        }
         String trimmedSubject = subject.trim();
+        if (trimmedSubject.equals("")) {
+            return null;
+        }
         if (!Subject.isValidSubject(trimmedSubject)) {
             throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
         }
@@ -215,7 +220,11 @@ public class ParserUtil {
         requireNonNull(subjects);
         final Set<Subject> subjectSet = new HashSet<>();
         for (String subjectName : subjects) {
-            subjectSet.add(parseSubject(subjectName));
+            Subject s = parseSubject(subjectName);
+            if (s == null) {
+                continue;
+            }
+            subjectSet.add(s);
         }
         return subjectSet;
     }
@@ -225,6 +234,10 @@ public class ParserUtil {
      */
     public static Level parseLevel(String level) {
         if (level == null) {
+            return new EmptyLevel();
+        }
+        String trimmedLevel = level.trim();
+        if (trimmedLevel.equals("")) {
             return new EmptyLevel();
         }
         if (!Level.isValidLevel(level)) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -29,6 +29,15 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
+    public static final String SPACE_PRECEDED_PREFIX_NAME = " " + PREFIX_NAME;
+    public static final String SPACE_PRECEDED_PREFIX_PHONE = " " + PREFIX_PHONE;
+    public static final String SPACE_PRECEDED_PREFIX_EMAIL = " " + PREFIX_EMAIL;
+    public static final String SPACE_PRECEDED_PREFIX_ADDRESS = " " + PREFIX_ADDRESS;
+    public static final String SPACE_PRECEDED_PREFIX_TAG = " " + PREFIX_TAG;
+    public static final String SPACE_PRECEDED_PREFIX_NOTE = " " + PREFIX_NOTE;
+    public static final String SPACE_PRECEDED_PREFIX_APPOINTMENT = " " + PREFIX_APPOINTMENT;
+    public static final String SPACE_PRECEDED_PREFIX_SUBJECT = " " + PREFIX_SUBJECT;
+    public static final String SPACE_PRECEDED_PREFIX_LEVEL = " " + PREFIX_LEVEL;
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -26,6 +26,12 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_CELINE;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_ADDRESS;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_EMAIL;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_LEVEL;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_NOTE;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_PHONE;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_SUBJECT;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_CELINE;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
@@ -199,30 +205,76 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
+        // zero tags or subjects
         Person expectedPerson = new PersonBuilder(AMY).withTags().removeLevel().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY,
                 new AddCommand(expectedPerson));
-
+        // empty subject prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_SUBJECT,
+                new AddCommand(expectedPerson));
+        // empty tag prefix value - FAILING - uncomment when fixed
+        // assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+        //         + SPACE_PRECEDED_PREFIX_TAG,
+        //         new AddCommand(expectedPerson));
         //No email field
         Person expectedPersonNoEmail = new PersonBuilder(NO_EMAIL_AMY).withTags().removeLevel().build();
+        //No prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY,
+                new AddCommand(expectedPersonNoEmail));
+        //Empty prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_EMAIL,
                 new AddCommand(expectedPersonNoEmail));
 
         //No address field
         Person expectedPersonNoAddress = new PersonBuilder(NO_ADDRESS_AMY).withTags().removeLevel().build();
+        //No prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + NOTE_DESC_AMY,
+                new AddCommand(expectedPersonNoAddress));
+        //Empty prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_ADDRESS,
                 new AddCommand(expectedPersonNoAddress));
 
         //No phone field
         Person expectedPersonNoPhone = new PersonBuilder(NO_PHONE_AMY).withTags().removeLevel().build();
+        //No prefix
         assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY,
+                new AddCommand(expectedPersonNoPhone));
+        //Empty prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_PHONE,
                 new AddCommand(expectedPersonNoPhone));
 
         //No Note field
         Person expectedPersonNoNote = new PersonBuilder(NO_NOTE_AMY).withTags().removeLevel().build();
+        //No prefix
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPersonNoNote));
+        //Empty prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_NOTE,
+                new AddCommand(expectedPersonNoNote));
+        //Multiple empty prefix values
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_NOTE + SPACE_PRECEDED_PREFIX_NOTE,
+                new AddCommand(expectedPersonNoNote));
+
+        //No Level field
+        Person expectedPersonNoLevel = new PersonBuilder(AMY).withTags().removeLevel().build();
+        //No prefix
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + NOTE_DESC_AMY,
+                new AddCommand(expectedPersonNoLevel));
+        //Empty prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + NOTE_DESC_AMY + SPACE_PRECEDED_PREFIX_LEVEL,
+                new AddCommand(expectedPersonNoLevel));
+        //Multiple empty prefix values
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + NOTE_DESC_AMY + SPACE_PRECEDED_PREFIX_LEVEL + SPACE_PRECEDED_PREFIX_LEVEL,
+                new AddCommand(expectedPersonNoLevel));
 
         //Only Name field
         Person expectedPersonNameOnly = new PersonBuilder(NAME_ONLY_CELINE).withTags().removeLevel().build();

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_PHONE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
@@ -215,6 +216,17 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_removeFields_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + SPACE_PRECEDED_PREFIX_PHONE;
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -15,7 +15,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_PHONE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -220,15 +220,4 @@ public class EditCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
-
-    @Test
-    public void parse_removeFields_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + SPACE_PRECEDED_PREFIX_PHONE;
-
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.EmptyAddress;
 import seedu.address.model.person.EmptyEmail;
+import seedu.address.model.person.EmptyLevel;
 import seedu.address.model.person.EmptyNote;
 import seedu.address.model.person.EmptyPhone;
 import seedu.address.model.person.Name;
@@ -254,5 +255,15 @@ public class ParserUtilTest {
         //Creating empty Notes
         assertEquals(ParserUtil.parseNote(""), new EmptyNote());
         assertEquals(ParserUtil.parseNote(null), new EmptyNote());
+
+        //Creating empty Subjects
+        assertEquals(ParserUtil.parseSubjects(Collections.emptyList()), new HashSet<>());
+        assertEquals(ParserUtil.parseSubjects(Arrays.asList("")), new HashSet<>());
+        assertEquals(ParserUtil.parseSubjects(Arrays.asList(" ")), new HashSet<>());
+        assertEquals(ParserUtil.parseSubjects(Arrays.asList("", " ")), new HashSet<>());
+
+        //Creating empty Levels
+        assertEquals(ParserUtil.parseLevel(""), new EmptyLevel());
+        assertEquals(ParserUtil.parseLevel(null), new EmptyLevel());
     }
 }


### PR DESCRIPTION
Fixes #134 and #158. I've also added some tests ensuring that prefixes with empty values are handled correctly.