### PR TITLE
Fix Appointment Bugs and in the Command Functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -15,6 +15,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.DisjointAppointmentList;
 import seedu.address.model.person.Person;
 
@@ -68,7 +69,13 @@ public class AddCommand extends Command {
         }
 
         // Overlapping appointment detection
+        // between appointments to be added and existing appointments
         if (model.appointmentsOverlap(toAdd.getAppointments().asUnmodifiableObservableList())) {
+            throw new CommandException(DisjointAppointmentList.MESSAGE_CONSTRAINTS);
+        }
+
+        // between two appointments to be added
+        if (Appointment.hasOverlapping(toAdd.getAppointments().asUnmodifiableObservableList())) {
             throw new CommandException(DisjointAppointmentList.MESSAGE_CONSTRAINTS);
         }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -129,6 +129,12 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+
+        // remove key's appointments
+        for (Appointment appointment : key.getAppointments()) {
+            appointments.remove(appointment);
+        }
+
         this.appointments.sort();
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_FRIDAY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +50,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_duplicateAppointments_throwsCommandException() {
-        Person personWithOverlappingAppointments = new PersonBuilder().withName("person").withAppointments(
+        Person personWithOverlappingAppointments = new PersonBuilder().withName("name").withAppointments(
                 VALID_APPOINTMENT_FRIDAY, VALID_APPOINTMENT_FRIDAY).build();
         assertCommandFailure(new AddCommand(personWithOverlappingAppointments), model,
                 DisjointAppointmentList.MESSAGE_CONSTRAINTS);
@@ -57,10 +58,16 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_overlappingAppointments_throwsCommandException() {
-        Person personWithOverlappingAppointments = new PersonBuilder().withName("person").withAppointments(
+        Person personWithOverlappingAppointments = new PersonBuilder().withName("name").withAppointments(
                 "10:00-12:00 SUN", "11:00-13:00 SUN").build();
         assertCommandFailure(new AddCommand(personWithOverlappingAppointments), model,
                 DisjointAppointmentList.MESSAGE_CONSTRAINTS);
     }
 
+    @Test
+    public void execute_overlappingAppointmentsWithExistingAppointments_throwsCommandException() {
+        Person personWithOverlappingAppointments = new PersonBuilder(BENSON).withName("notBenson").build();
+        assertCommandFailure(new AddCommand(personWithOverlappingAppointments), model,
+                DisjointAppointmentList.MESSAGE_CONSTRAINTS);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_FRIDAY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -11,6 +12,7 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.appointment.DisjointAppointmentList;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -43,6 +45,22 @@ public class AddCommandIntegrationTest {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model,
                 AddCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_duplicateAppointments_throwsCommandException() {
+        Person personWithOverlappingAppointments = new PersonBuilder().withName("person").withAppointments(
+                VALID_APPOINTMENT_FRIDAY, VALID_APPOINTMENT_FRIDAY).build();
+        assertCommandFailure(new AddCommand(personWithOverlappingAppointments), model,
+                DisjointAppointmentList.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void execute_overlappingAppointments_throwsCommandException() {
+        Person personWithOverlappingAppointments = new PersonBuilder().withName("person").withAppointments(
+                "10:00-12:00 SUN", "11:00-13:00 SUN").build();
+        assertCommandFailure(new AddCommand(personWithOverlappingAppointments), model,
+                DisjointAppointmentList.MESSAGE_CONSTRAINTS);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_FRIDAY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -145,6 +146,26 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_overlappingAppointmentUnfilteredList_failure() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).withAppointments(
+                "10:00-13:00 SUN").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_OVERLAPPING_APPOINTMENT);
+    }
+
+    @Test
+    public void execute_overlappingAppointments_failure() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).withAppointments(
+                VALID_APPOINTMENT_FRIDAY, VALID_APPOINTMENT_FRIDAY).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_OVERLAPPING_APPOINTMENT);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_FRI
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -81,6 +83,40 @@ public class AddressBookTest {
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
     }
+
+    @Test
+    public void addPerson_personInAddressBook_throwDuplicatePersonException() {
+        addressBook.addPerson(ALICE);
+        assertThrows(DuplicatePersonException.class, () -> addressBook.addPerson(ALICE));
+    }
+
+    @Test
+    public void addPerson_personNotInAddressBook_success() {
+        assertFalse(addressBook.hasPerson(BENSON));
+        assertTrue(addressBook.getAppointmentList().isEmpty());
+        addressBook.addPerson(BENSON);
+        assertTrue(addressBook.hasPerson(BENSON));
+        assertFalse(BENSON.getAppointments().isEmpty());
+        assertFalse(addressBook.getAppointmentList().isEmpty());
+    }
+
+    @Test
+    public void removePerson_personInAddressBook_success() {
+        addressBook.addPerson(BENSON);
+        assertFalse(addressBook.getAppointmentList().isEmpty());
+
+        addressBook.removePerson(BENSON);
+        assertFalse(addressBook.hasPerson(BENSON));
+        assertTrue(addressBook.getAppointmentList().isEmpty());
+    }
+
+    @Test
+    public void removePerson_personNotInAddressBook_throwPersonNotFoundException() {
+        addressBook.addPerson(BENSON);
+        assertTrue(addressBook.hasPerson(BENSON));
+        assertThrows(PersonNotFoundException.class, () -> addressBook.removePerson(ALICE));
+    }
+
 
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -95,6 +97,21 @@ public class ModelManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void deletePerson_personInAddressBook_success() {
+        modelManager.addPerson(BENSON);
+        modelManager.deletePerson(BENSON);
+        assertFalse(modelManager.hasPerson(BENSON));
+        assertTrue(modelManager.getFilteredAppointmentList().isEmpty());
+    }
+
+    @Test
+    public void deletePerson_personNotInAddressBook_failure() {
+        modelManager.addPerson(BENSON);
+        assertTrue(modelManager.hasPerson(BENSON));
+        assertThrows(PersonNotFoundException.class, () -> modelManager.deletePerson(ALICE));
     }
 
     //// tests for appointment

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -97,21 +95,6 @@ public class ModelManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
-    }
-
-    @Test
-    public void deletePerson_personInAddressBook_success() {
-        modelManager.addPerson(BENSON);
-        modelManager.deletePerson(BENSON);
-        assertFalse(modelManager.hasPerson(BENSON));
-        assertTrue(modelManager.getFilteredAppointmentList().isEmpty());
-    }
-
-    @Test
-    public void deletePerson_personNotInAddressBook_failure() {
-        modelManager.addPerson(BENSON);
-        assertTrue(modelManager.hasPerson(BENSON));
-        assertThrows(PersonNotFoundException.class, () -> modelManager.deletePerson(ALICE));
     }
 
     //// tests for appointment

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -81,28 +81,33 @@ public class AppointmentTest {
     }
 
     @Test
-    public void overlapsWith() {
+    public void overlapsWith_overlappingAppointment_returnsTrue() {
         Appointment appointment = new Appointment("10:00-12:00 FRI");
-        Appointment overlappingAppointment = new Appointment("11:00-13:00 FRI");
 
+        Appointment overlappingAppointment = new Appointment("11:00-13:00 FRI");
         assertTrue(appointment.overlapsWith(overlappingAppointment));
         assertTrue(overlappingAppointment.overlapsWith(appointment));
 
         overlappingAppointment = new Appointment("10:00-11:00 FRI");
-
         assertTrue(appointment.overlapsWith(overlappingAppointment));
         assertTrue(overlappingAppointment.overlapsWith(appointment));
 
         overlappingAppointment = new Appointment("11:00-13:00 FRI");
-
         assertTrue(appointment.overlapsWith(overlappingAppointment));
         assertTrue(overlappingAppointment.overlapsWith(appointment));
 
         overlappingAppointment = new Appointment("11:00-12:00 FRI");
-
         assertTrue(appointment.overlapsWith(overlappingAppointment));
         assertTrue(overlappingAppointment.overlapsWith(appointment));
 
+        overlappingAppointment = new Appointment("10:00-12:00 FRI");
+        assertTrue(appointment.overlapsWith(overlappingAppointment));
+        assertTrue(overlappingAppointment.overlapsWith(appointment));
+    }
+
+    @Test
+    public void overlapsWith_nonOverlappingAppointment_returnsFalse() {
+        Appointment appointment = new Appointment("10:00-12:00 FRI");
         Appointment notOverlappingAppointment = new Appointment("12:00-14:00 FRI");
 
         assertFalse(appointment.overlapsWith(notOverlappingAppointment));
@@ -112,7 +117,6 @@ public class AppointmentTest {
 
         assertFalse(appointment.overlapsWith(notOverlappingAppointment));
         assertFalse(notOverlappingAppointment.overlapsWith(appointment));
-
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses several bugs related to appointments and enhances command functionality for better user experience. The following commits are included under the branch fix-appointment-bugs:

- Fix DeleteCommand Bug: Resolves an issue where appointments were not being removed after deleting a person. This bug affected the integrity of the address book data.

- Fix AddCommand Bug: Addresses a bug where users could add persons with overlapping appointments. This issue contradicted the application's intended behavior of preventing overlapping appointments.

- Refactor AppointmentTest: Enhances the AppointmentTest class, likely improving test coverage and code maintainability.

These changes aim to improve the overall reliability and functionality of the application. Additionally, the following issues are resolved and closed with this pull request:

**Bug: Unable to make appointments back-to-back (#151):** This issue prevented users from scheduling appointments back-to-back, which is a common requirement. The fix likely resolves this compound bug originating from the DeleteCommand.

**User able to add persons with overlapping appointments (#187):** Resolves a bug where users could add new persons with overlapping appointments, contradicting the intended behavior of the application.

**Data of address book is wiped after deleting a person with existing appointments (#165):** Addresses a bug where the data of the address book was wiped after deleting a person with existing appointments. This was likely another compound bug fixed as part of this pull request.

**Unable to add student after deleting him/her (#148):** Addresses a bug where a student cannot be added back to the address book after deleting due to clash with existing appointments. This was likely another compound bug fixed as part of this pull request.

