### PR TITLE
Fix bug in command return message for appointments

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -53,7 +53,7 @@ public class Messages {
         person.getTags().forEach(builder::append);
 
         builder.append("; Appointments: ");
-        person.getAppointments().forEach(builder::append);
+        builder.append(person.getAppointments());
 
         builder.append("; Subjects: ");
         person.getSubjects().forEach(builder::append);

--- a/src/main/java/seedu/address/model/appointment/AppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentList.java
@@ -5,6 +5,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -101,7 +103,10 @@ public class AppointmentList implements Iterable<Appointment> {
 
     @Override
     public String toString() {
-        return internalList.toString();
+        List<String> appointmentStrings = internalList.stream()
+                .map(Appointment::toString).collect(Collectors.toList());
+        return String.join(", ", appointmentStrings);
+
     }
 
     /**


### PR DESCRIPTION
Fixes #166

Before, appointment strings in the return message for `add`, `edit`, and `delete` commands were displayed without separation which is difficult to read. Now, the appointment strings are separated with ", " delimiters.

Changes were made to the `AppointmentList` and `Messages` class for this fix.

- `add` command:
![image](https://github.com/AY2324S2-CS2103-F09-3/tp/assets/108804868/d3f5fb05-ed9e-48fa-a820-51ce6ea12605)
- `edit` command:
![image](https://github.com/AY2324S2-CS2103-F09-3/tp/assets/108804868/6a71944d-f4ad-4997-a0e4-e340aa753e76)
- `delete` command:
![image](https://github.com/AY2324S2-CS2103-F09-3/tp/assets/108804868/719db219-39b2-4ea5-bd8b-743c009002f5)
