### PR TITLE
Update Add command to allow for blank `ap/` and `t/`

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -159,6 +159,9 @@ public class ParserUtil {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
+            if (tagName.isEmpty()) {
+                continue;
+            }
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
@@ -184,6 +187,9 @@ public class ParserUtil {
         requireNonNull(appointments);
         final AppointmentList appointmentList = new AppointmentList();
         for (String ap : appointments) {
+            if (ap.isEmpty()) {
+                continue;
+            }
             Appointment appointment = parseAppointment(ap);
             /*if (appointmentList.overlaps(appointment)) {
                 throw new ParseException(DisjointAppointmentList.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -27,11 +27,13 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_CELINE;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_ADDRESS;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_APPOINTMENT;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_EMAIL;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_LEVEL;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_NOTE;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_PHONE;
 import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_SUBJECT;
+import static seedu.address.logic.commands.CommandTestUtil.SPACE_PRECEDED_PREFIX_TAG;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_CELINE;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
@@ -213,10 +215,15 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
                 + SPACE_PRECEDED_PREFIX_SUBJECT,
                 new AddCommand(expectedPerson));
-        // empty tag prefix value - FAILING - uncomment when fixed
-        // assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
-        //         + SPACE_PRECEDED_PREFIX_TAG,
-        //         new AddCommand(expectedPerson));
+        // empty tag prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_TAG,
+                new AddCommand(expectedPerson));
+        // empty appointment prefix value
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NOTE_DESC_AMY
+                + SPACE_PRECEDED_PREFIX_APPOINTMENT,
+                new AddCommand(expectedPerson));
+
         //No email field
         Person expectedPersonNoEmail = new PersonBuilder(NO_EMAIL_AMY).withTags().removeLevel().build();
         //No prefix

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -15,19 +15,26 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MT;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_FRIDAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_SUNDAY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_MATH;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_MT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -52,6 +59,7 @@ public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
     private static final String APPOINTMENT_EMPTY = " " + PREFIX_APPOINTMENT;
+    private static final String SUBJECT_EMPTY = " " + PREFIX_SUBJECT;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
@@ -97,24 +105,52 @@ public class EditCommandParserTest {
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-
-        // similarly, parsing {@code PREFIX_APPOINTMENT} alone will reset the appointment
-        // of the {@code Person} being edited, parsing it together with a valid appointment results in error
-        assertParseFailure(parser, "1" + APPOINTMENT_DESC_FRIDAY
-                + APPOINTMENT_DESC_SUNDAY + APPOINTMENT_EMPTY, Appointment.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + APPOINTMENT_DESC_FRIDAY
-                + APPOINTMENT_EMPTY + APPOINTMENT_DESC_SUNDAY, Appointment.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + APPOINTMENT_EMPTY
-                + APPOINTMENT_DESC_FRIDAY + APPOINTMENT_DESC_SUNDAY, Appointment.MESSAGE_CONSTRAINTS);
-
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_multipleEmptyAndFilledValues_success() {
+        // Parser should allow any combination of empty fields and filled fields for fields containing multiple values
+        Index targetIndex = INDEX_FIRST_PERSON;
+
+        // Tags
+        EditPersonDescriptor personWithTags = new EditPersonDescriptorBuilder()
+                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
+        EditCommand expectedCommandTags = new EditCommand(targetIndex, personWithTags);
+        assertParseSuccess(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, expectedCommandTags);
+        assertParseSuccess(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, expectedCommandTags);
+        assertParseSuccess(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, expectedCommandTags);
+        assertParseSuccess(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND
+                + TAG_EMPTY, expectedCommandTags);
+
+        // Appointments
+        EditPersonDescriptor personWithAppointments = new EditPersonDescriptorBuilder()
+                .withAppointments(VALID_APPOINTMENT_FRIDAY, VALID_APPOINTMENT_SUNDAY).build();
+        EditCommand expectedCommandAppointments = new EditCommand(targetIndex, personWithAppointments);
+        assertParseSuccess(parser, "1" + APPOINTMENT_DESC_FRIDAY
+                + APPOINTMENT_DESC_SUNDAY + APPOINTMENT_EMPTY, expectedCommandAppointments);
+        assertParseSuccess(parser, "1" + APPOINTMENT_DESC_FRIDAY
+                + APPOINTMENT_EMPTY + APPOINTMENT_DESC_SUNDAY, expectedCommandAppointments);
+        assertParseSuccess(parser, "1" + APPOINTMENT_EMPTY
+                + APPOINTMENT_DESC_FRIDAY + APPOINTMENT_DESC_SUNDAY, expectedCommandAppointments);
+        assertParseSuccess(parser, "1" + APPOINTMENT_EMPTY
+                + APPOINTMENT_DESC_FRIDAY + APPOINTMENT_EMPTY + APPOINTMENT_DESC_SUNDAY
+                + APPOINTMENT_EMPTY, expectedCommandAppointments);
+
+        // Subjects
+        EditPersonDescriptor personWithSubjects = new EditPersonDescriptorBuilder()
+                .withSubjects(VALID_SUBJECT_MT, VALID_SUBJECT_MATH).build();
+        EditCommand expectedCommandSubjects = new EditCommand(targetIndex, personWithSubjects);
+        assertParseSuccess(parser, "1" + SUBJECT_DESC_MATH
+                + SUBJECT_DESC_MT + SUBJECT_EMPTY, expectedCommandSubjects);
+        assertParseSuccess(parser, "1" + SUBJECT_DESC_MATH
+                + SUBJECT_EMPTY + SUBJECT_DESC_MT, expectedCommandSubjects);
+        assertParseSuccess(parser, "1" + SUBJECT_EMPTY
+                + SUBJECT_DESC_MATH + SUBJECT_DESC_MT, expectedCommandSubjects);
+        assertParseSuccess(parser, "1" + SUBJECT_EMPTY + SUBJECT_DESC_MATH
+                + SUBJECT_EMPTY + SUBJECT_DESC_MT + SUBJECT_EMPTY, expectedCommandSubjects);
     }
 
     @Test


### PR DESCRIPTION
Fixes #192 and #193

Also added additional test cases to handle new behavior of blank `ap/` and `t/` files, that being that it will be treated as a blank input, ie `t/Tag1 t/ t/Tag2` will be treated as `t/Tag1 t/Tag2`